### PR TITLE
MPIR.Net to use mpz_get_2exp_d

### DIFF
--- a/mpir.net/mpir.net-tests/HugeIntTests/Conversions.cs
+++ b/mpir.net/mpir.net-tests/HugeIntTests/Conversions.cs
@@ -117,7 +117,7 @@ namespace MPIR.Tests.HugeIntTests
                 var source = Platform.Select(-123.45e20, -123.45e19);
                 var zillion = Platform.Ui(10000000000U, 1000000000U);
                 var factor = Platform.Ui(1, 10);
-                var exp = 0;
+                var exp = Platform.Si(0, 0);
 
                 a.SetTo(source);
                 lo.Value = (a/zillion).Rounding(RoundingModes.Floor);

--- a/mpir.net/mpir.net/HugeInt.h
+++ b/mpir.net/mpir.net/HugeInt.h
@@ -1674,12 +1674,11 @@ namespace MPIR
             /// </summary>
             /// <param name="exp">variable to store the exponent in.</param>
             /// <returns>The mantissa of the value as a double, possibly truncated.</returns>
-            double ToDouble([Out] mp_exp_t% exp) 
+            double ToDouble([Out] mpir_si% exp)
             { 
-                mp_exp_t x; 
-                auto result = MP(get_d_2exp)(&x, _value); 
-                exp = x; 
-                return result; 
+                double result;
+                exp = MP(get_2exp_d)(&result, _value);
+                return result;
             }
 
             #pragma endregion


### PR DESCRIPTION
Switched MPIR.Net HugeInt.ToDouble(out exp) method to use mpz_get_2exp_d instead of mpz_get_d_2exp.

This should be the last change to bring MPIR.Net up to date.