### PR TITLE
Fixed incorrect pre-build command in vs13 mpir-tests projects.

### DIFF
--- a/msvc/vs13/mpir-tests/add-test-lib/add-test-lib.vcxproj
+++ b/msvc/vs13/mpir-tests/add-test-lib/add-test-lib.vcxproj
@@ -74,7 +74,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -90,7 +90,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -109,8 +109,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
-      </Command>
+check_config $(Platform) $(Configuration) 13      </Command>
     </PreBuildEvent>
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -122,7 +121,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/bswap/bswap.vcxproj
+++ b/msvc/vs13/mpir-tests/bswap/bswap.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/constants/constants.vcxproj
+++ b/msvc/vs13/mpir-tests/constants/constants.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/count_zeros/count_zeros.vcxproj
+++ b/msvc/vs13/mpir-tests/count_zeros/count_zeros.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -141,7 +141,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.assign/cxx.assign.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.assign/cxx.assign.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.binary/cxx.binary.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.binary/cxx.binary.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.cast/cxx.cast.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.cast/cxx.cast.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.constr/cxx.constr.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.constr/cxx.constr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.headers/cxx.headers.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.headers/cxx.headers.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.istream/cxx.istream.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.istream/cxx.istream.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.locale/cxx.locale.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.locale/cxx.locale.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.misc/cxx.misc.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.misc/cxx.misc.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -144,7 +144,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.ops/cxx.ops.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.ops/cxx.ops.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -144,7 +144,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.ostream/cxx.ostream.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.ostream/cxx.ostream.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.prec/cxx.prec.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.prec/cxx.prec.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.rand/cxx.rand.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.rand/cxx.rand.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -97,7 +97,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -122,7 +122,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -146,7 +146,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.ternary/cxx.ternary.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.ternary/cxx.ternary.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -119,7 +119,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -141,7 +141,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/cxx.unary/cxx.unary.vcxproj
+++ b/msvc/vs13/mpir-tests/cxx.unary/cxx.unary.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.adjust/f.adjust.vcxproj
+++ b/msvc/vs13/mpir-tests/f.adjust/f.adjust.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.adjust_sqrt2/f.adjust_sqrt2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.adjust_sqrt2/f.adjust_sqrt2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.butterfly/f.butterfly.vcxproj
+++ b/msvc/vs13/mpir-tests/f.butterfly/f.butterfly.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.butterfly_lshb/f.butterfly_lshb.vcxproj
+++ b/msvc/vs13/mpir-tests/f.butterfly_lshb/f.butterfly_lshb.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.butterfly_rshb/f.butterfly_rshb.vcxproj
+++ b/msvc/vs13/mpir-tests/f.butterfly_rshb/f.butterfly_rshb.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.butterfly_sqrt2/f.butterfly_sqrt2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.butterfly_sqrt2/f.butterfly_sqrt2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.butterfly_twiddle/f.butterfly_twiddle.vcxproj
+++ b/msvc/vs13/mpir-tests/f.butterfly_twiddle/f.butterfly_twiddle.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.div_2expmod_2expp1/f.div_2expmod_2expp1.vcxproj
+++ b/msvc/vs13/mpir-tests/f.div_2expmod_2expp1/f.div_2expmod_2expp1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.fft_ifft_mfa_trunc_sqrt2/f.fft_ifft_mfa_trunc_sqrt2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.fft_ifft_mfa_trunc_sqrt2/f.fft_ifft_mfa_trunc_sqrt2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.fft_ifft_negacyclic/f.fft_ifft_negacyclic.vcxproj
+++ b/msvc/vs13/mpir-tests/f.fft_ifft_negacyclic/f.fft_ifft_negacyclic.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.fft_ifft_radix2/f.fft_ifft_radix2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.fft_ifft_radix2/f.fft_ifft_radix2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.fft_ifft_trunc/f.fft_ifft_trunc.vcxproj
+++ b/msvc/vs13/mpir-tests/f.fft_ifft_trunc/f.fft_ifft_trunc.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.fft_ifft_trunc_sqrt2/f.fft_ifft_trunc_sqrt2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.fft_ifft_trunc_sqrt2/f.fft_ifft_trunc_sqrt2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.mul_2expmod_2expp1/f.mul_2expmod_2expp1.vcxproj
+++ b/msvc/vs13/mpir-tests/f.mul_2expmod_2expp1/f.mul_2expmod_2expp1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.mul_fft_main/f.mul_fft_main.vcxproj
+++ b/msvc/vs13/mpir-tests/f.mul_fft_main/f.mul_fft_main.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.mul_mfa_trunc_sqrt2/f.mul_mfa_trunc_sqrt2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.mul_mfa_trunc_sqrt2/f.mul_mfa_trunc_sqrt2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.mul_trunc_sqrt2/f.mul_trunc_sqrt2.vcxproj
+++ b/msvc/vs13/mpir-tests/f.mul_trunc_sqrt2/f.mul_trunc_sqrt2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.mulmod_2expp1/f.mulmod_2expp1.vcxproj
+++ b/msvc/vs13/mpir-tests/f.mulmod_2expp1/f.mulmod_2expp1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.normmod_2expp1/f.normmod_2expp1.vcxproj
+++ b/msvc/vs13/mpir-tests/f.normmod_2expp1/f.normmod_2expp1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/f.split_combine_bits/f.split_combine_bits.vcxproj
+++ b/msvc/vs13/mpir-tests/f.split_combine_bits/f.split_combine_bits.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/gmpmax/gmpmax.vcxproj
+++ b/msvc/vs13/mpir-tests/gmpmax/gmpmax.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/hightomask/hightomask.vcxproj
+++ b/msvc/vs13/mpir-tests/hightomask/hightomask.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/misc.locale/misc.locale.vcxproj
+++ b/msvc/vs13/mpir-tests/misc.locale/misc.locale.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/misc.printf/misc.printf.vcxproj
+++ b/msvc/vs13/mpir-tests/misc.printf/misc.printf.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/misc.scanf/misc.scanf.vcxproj
+++ b/msvc/vs13/mpir-tests/misc.scanf/misc.scanf.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/modlinv/modlinv.vcxproj
+++ b/msvc/vs13/mpir-tests/modlinv/modlinv.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.add/mpf.add.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.add/mpf.add.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.cmp_d/mpf.cmp_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.cmp_d/mpf.cmp_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.cmp_si/mpf.cmp_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.cmp_si/mpf.cmp_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.conv/mpf.conv.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.conv/mpf.conv.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.div/mpf.div.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.div/mpf.div.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.dm2exp/mpf.dm2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.dm2exp/mpf.dm2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.eq/mpf.eq.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.eq/mpf.eq.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.fits/mpf.fits.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.fits/mpf.fits.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.get_d/mpf.get_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.get_d/mpf.get_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.get_d_2exp/mpf.get_d_2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.get_d_2exp/mpf.get_d_2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.get_si/mpf.get_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.get_si/mpf.get_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.get_ui/mpf.get_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.get_ui/mpf.get_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.gsprec/mpf.gsprec.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.gsprec/mpf.gsprec.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.inp_str/mpf.inp_str.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.inp_str/mpf.inp_str.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.int_p/mpf.int_p.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.int_p/mpf.int_p.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.mul_ui/mpf.mul_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.mul_ui/mpf.mul_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -144,7 +144,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.muldiv/mpf.muldiv.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.muldiv/mpf.muldiv.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.reuse/mpf.reuse.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.reuse/mpf.reuse.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.set/mpf.set.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.set/mpf.set.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.set_q/mpf.set_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.set_q/mpf.set_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.set_si/mpf.set_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.set_si/mpf.set_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.set_ui/mpf.set_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.set_ui/mpf.set_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.sqrt/mpf.sqrt.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.sqrt/mpf.sqrt.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.sqrt_ui/mpf.sqrt_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.sqrt_ui/mpf.sqrt_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.sub/mpf.sub.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.sub/mpf.sub.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.trunc/mpf.trunc.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.trunc/mpf.trunc.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpf.ui_div/mpf.ui_div.vcxproj
+++ b/msvc/vs13/mpir-tests/mpf.ui_div/mpf.ui_div.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -96,7 +96,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -120,7 +120,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -143,7 +143,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.addadd_n/mpn.addadd_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.addadd_n/mpn.addadd_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.addsub_n/mpn.addsub_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.addsub_n/mpn.addsub_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.aors_1/mpn.aors_1.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.aors_1/mpn.aors_1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.asmtype/mpn.asmtype.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.asmtype/mpn.asmtype.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_bdiv_q/mpn.dc_bdiv_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_bdiv_q/mpn.dc_bdiv_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_bdiv_q_n/mpn.dc_bdiv_q_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_bdiv_q_n/mpn.dc_bdiv_q_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_bdiv_qr/mpn.dc_bdiv_qr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_bdiv_qr/mpn.dc_bdiv_qr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_bdiv_qr_n/mpn.dc_bdiv_qr_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_bdiv_qr_n/mpn.dc_bdiv_qr_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_div_q/mpn.dc_div_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_div_q/mpn.dc_div_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_div_qr/mpn.dc_div_qr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_div_qr/mpn.dc_div_qr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_div_qr_n/mpn.dc_div_qr_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_div_qr_n/mpn.dc_div_qr_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.dc_divappr_q/mpn.dc_divappr_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.dc_divappr_q/mpn.dc_divappr_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.divebyff/mpn.divebyff.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.divebyff/mpn.divebyff.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.divebyfobm1/mpn.divebyfobm1.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.divebyfobm1/mpn.divebyfobm1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.divrem_1/mpn.divrem_1.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.divrem_1/mpn.divrem_1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.gcdext/mpn.gcdext.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.gcdext/mpn.gcdext.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.get_d/mpn.get_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.get_d/mpn.get_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.hgcd/mpn.hgcd.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.hgcd/mpn.hgcd.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.instrument/mpn.instrument.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.instrument/mpn.instrument.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.inv_div_q/mpn.inv_div_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.inv_div_q/mpn.inv_div_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.inv_div_qr/mpn.inv_div_qr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.inv_div_qr/mpn.inv_div_qr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.inv_div_qr_n/mpn.inv_div_qr_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.inv_div_qr_n/mpn.inv_div_qr_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.inv_divappr_q/mpn.inv_divappr_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.inv_divappr_q/mpn.inv_divappr_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.invert/mpn.invert.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.invert/mpn.invert.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.iord_u/mpn.iord_u.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.iord_u/mpn.iord_u.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.lorrshift1/mpn.lorrshift1.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.lorrshift1/mpn.lorrshift1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.matrix22/mpn.matrix22.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.matrix22/mpn.matrix22.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.mp_bases/mpn.mp_bases.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.mp_bases/mpn.mp_bases.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.mullow_basecase/mpn.mullow_basecase.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.mullow_basecase/mpn.mullow_basecase.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.mullowhigh/mpn.mullowhigh.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.mullowhigh/mpn.mullowhigh.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.mulmid/mpn.mulmid.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.mulmid/mpn.mulmid.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.mulmod_2expm1/mpn.mulmod_2expm1.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.mulmod_2expm1/mpn.mulmod_2expm1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.neg/mpn.neg.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.neg/mpn.neg.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.perfsqr/mpn.perfsqr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.perfsqr/mpn.perfsqr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.redc_1/mpn.redc_1.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.redc_1/mpn.redc_1.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.sb_bdiv_q/mpn.sb_bdiv_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.sb_bdiv_q/mpn.sb_bdiv_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.sb_bdiv_qr/mpn.sb_bdiv_qr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.sb_bdiv_qr/mpn.sb_bdiv_qr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.sb_div_q/mpn.sb_div_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.sb_div_q/mpn.sb_div_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.sb_div_qr/mpn.sb_div_qr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.sb_div_qr/mpn.sb_div_qr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.sb_divappr_q/mpn.sb_divappr_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.sb_divappr_q/mpn.sb_divappr_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.scan/mpn.scan.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.scan/mpn.scan.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.sizeinbase/mpn.sizeinbase.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.sizeinbase/mpn.sizeinbase.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.subadd_n/mpn.subadd_n.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.subadd_n/mpn.subadd_n.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.tdiv_q/mpn.tdiv_q.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.tdiv_q/mpn.tdiv_q.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpn.tdiv_qr/mpn.tdiv_qr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpn.tdiv_qr/mpn.tdiv_qr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.aors/mpq.aors.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.aors/mpq.aors.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.cmp/mpq.cmp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.cmp/mpq.cmp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.cmp_si/mpq.cmp_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.cmp_si/mpq.cmp_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.cmp_ui/mpq.cmp_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.cmp_ui/mpq.cmp_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.equal/mpq.equal.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.equal/mpq.equal.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.get_d/mpq.get_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.get_d/mpq.get_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.get_str/mpq.get_str.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.get_str/mpq.get_str.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.inp_str/mpq.inp_str.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.inp_str/mpq.inp_str.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.md_2exp/mpq.md_2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.md_2exp/mpq.md_2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.set_f/mpq.set_f.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.set_f/mpq.set_f.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpq.set_str/mpq.set_str.vcxproj
+++ b/msvc/vs13/mpir-tests/mpq.set_str/mpq.set_str.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.addsub/mpz.addsub.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.addsub/mpz.addsub.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.aorsmul/mpz.aorsmul.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.aorsmul/mpz.aorsmul.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.bin/mpz.bin.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.bin/mpz.bin.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.bit/mpz.bit.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.bit/mpz.bit.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.cdiv_ui/mpz.cdiv_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.cdiv_ui/mpz.cdiv_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.cmp/mpz.cmp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.cmp/mpz.cmp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.cmp_d/mpz.cmp_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.cmp_d/mpz.cmp_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.cmp_si/mpz.cmp_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.cmp_si/mpz.cmp_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.cong/mpz.cong.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.cong/mpz.cong.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.cong_2exp/mpz.cong_2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.cong_2exp/mpz.cong_2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.convert/mpz.convert.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.convert/mpz.convert.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.div_2exp/mpz.div_2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.div_2exp/mpz.div_2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.dive/mpz.dive.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.dive/mpz.dive.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.dive_ui/mpz.dive_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.dive_ui/mpz.dive_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.divis/mpz.divis.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.divis/mpz.divis.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.divis_2exp/mpz.divis_2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.divis_2exp/mpz.divis_2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.export/mpz.export.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.export/mpz.export.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.fac_ui/mpz.fac_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.fac_ui/mpz.fac_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.fdiv/mpz.fdiv.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.fdiv/mpz.fdiv.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.fdiv_ui/mpz.fdiv_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.fdiv_ui/mpz.fdiv_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.fib_ui/mpz.fib_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.fib_ui/mpz.fib_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.fits/mpz.fits.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.fits/mpz.fits.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.gcd/mpz.gcd.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.gcd/mpz.gcd.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.gcd_ui/mpz.gcd_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.gcd_ui/mpz.gcd_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.get_d/mpz.get_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.get_d/mpz.get_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.get_d_2exp/mpz.get_d_2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.get_d_2exp/mpz.get_d_2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.get_si/mpz.get_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.get_si/mpz.get_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.get_sx/mpz.get_sx.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.get_sx/mpz.get_sx.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -139,7 +139,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.get_ux/mpz.get_ux.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.get_ux/mpz.get_ux.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -139,7 +139,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.hamdist/mpz.hamdist.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.hamdist/mpz.hamdist.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.import/mpz.import.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.import/mpz.import.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.inp_str/mpz.inp_str.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.inp_str/mpz.inp_str.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.io/mpz.io.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.io/mpz.io.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.io_raw/mpz.io_raw.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.io_raw/mpz.io_raw.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.jac/mpz.jac.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.jac/mpz.jac.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.lcm/mpz.lcm.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.lcm/mpz.lcm.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.likely_prime_p/mpz.likely_prime_p.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.likely_prime_p/mpz.likely_prime_p.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.limbs/mpz.limbs.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.limbs/mpz.limbs.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.logic/mpz.logic.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.logic/mpz.logic.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.lucnum_ui/mpz.lucnum_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.lucnum_ui/mpz.lucnum_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.mfac_uiui/mpz.mfac_uiui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.mfac_uiui/mpz.mfac_uiui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.mul/mpz.mul.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.mul/mpz.mul.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.mul_i/mpz.mul_i.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.mul_i/mpz.mul_i.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.next_prime_candidate/mpz.next_prime_candidate.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.next_prime_candidate/mpz.next_prime_candidate.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.oddeven/mpz.oddeven.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.oddeven/mpz.oddeven.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.perfpow/mpz.perfpow.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.perfpow/mpz.perfpow.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.perfsqr/mpz.perfsqr.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.perfsqr/mpz.perfsqr.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.popcount/mpz.popcount.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.popcount/mpz.popcount.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.pow/mpz.pow.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.pow/mpz.pow.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.powm/mpz.powm.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.powm/mpz.powm.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.powm_ui/mpz.powm_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.powm_ui/mpz.powm_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.pprime_p/mpz.pprime_p.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.pprime_p/mpz.pprime_p.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.primorial_ui/mpz.primorial_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.primorial_ui/mpz.primorial_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.reuse/mpz.reuse.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.reuse/mpz.reuse.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.root/mpz.root.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.root/mpz.root.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.scan/mpz.scan.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.scan/mpz.scan.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.set_d/mpz.set_d.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.set_d/mpz.set_d.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.set_f/mpz.set_f.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.set_f/mpz.set_f.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.set_si/mpz.set_si.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.set_si/mpz.set_si.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.set_str/mpz.set_str.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.set_str/mpz.set_str.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.set_sx/mpz.set_sx.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.set_sx/mpz.set_sx.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.set_ux/mpz.set_ux.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.set_ux/mpz.set_ux.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.sizeinbase/mpz.sizeinbase.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.sizeinbase/mpz.sizeinbase.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.sqrtrem/mpz.sqrtrem.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.sqrtrem/mpz.sqrtrem.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.tdiv/mpz.tdiv.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.tdiv/mpz.tdiv.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.tdiv_ui/mpz.tdiv_ui.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.tdiv_ui/mpz.tdiv_ui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/mpz.trial_division/mpz.trial_division.vcxproj
+++ b/msvc/vs13/mpir-tests/mpz.trial_division/mpz.trial_division.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/parity/parity.vcxproj
+++ b/msvc/vs13/mpir-tests/parity/parity.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/popc/popc.vcxproj
+++ b/msvc/vs13/mpir-tests/popc/popc.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.iset/rand.iset.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.iset/rand.iset.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.lc2exp/rand.lc2exp.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.lc2exp/rand.lc2exp.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.mt/rand.mt.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.mt/rand.mt.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.rand/rand.rand.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.rand/rand.rand.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.urbui/rand.urbui.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.urbui/rand.urbui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.urmui/rand.urmui.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.urmui/rand.urmui.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/rand.urndmm/rand.urndmm.vcxproj
+++ b/msvc/vs13/mpir-tests/rand.urndmm/rand.urndmm.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>

--- a/msvc/vs13/mpir-tests/subc/subc.vcxproj
+++ b/msvc/vs13/mpir-tests/subc/subc.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -95,7 +95,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>
@@ -118,7 +118,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <ClCompile>
@@ -140,7 +140,7 @@ check_config $(Platform) $(Configuration) 15
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>cd ..\..\..\ 
-check_config $(Platform) $(Configuration) 15
+check_config $(Platform) $(Configuration) 13
       </Command>
     </PreBuildEvent>
     <Midl>


### PR DESCRIPTION
VS13 mpir-tests expect mpir built with VS2013.
