### PR TITLE
Improve vsyasm.props

### DIFF
--- a/msvc/vsyasm.props
+++ b/msvc/vsyasm.props
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <YASM_PATH Condition= "'$(YASM_PATH)' == ''">C:\Program Files\yasm\</YASM_PATH>
+    <YASM_NAME Condition= "'$(YASM_NAME)' == ''">yasm.exe</YASM_NAME>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <YASM>
@@ -18,7 +19,7 @@
       <ObjectFile>$(IntDir)%(FileName).obj</ObjectFile>
       <PreProc>0</PreProc>
       <Parser>0</Parser>
-      <CommandLineTemplate>"$(YASM_PATH.TrimEnd('\'))"\vsyasm.exe -Xvc -f $(Platform) [AllOptions] [AdditionalOptions] [Inputs]</CommandLineTemplate>
+      <CommandLineTemplate>"$(YASM_PATH.TrimEnd('\'))\$(YASM_NAME)" -Xvc -f $(Platform) [AllOptions] [AdditionalOptions] [Inputs]</CommandLineTemplate>
       <Outputs>%(ObjectFile)</Outputs>
       <ExecutionDescription>Assembling %(Filename)%(Extension) ==> $(IntDir)%(FileName).obj</ExecutionDescription>
       <ShowOnlyRuleProperties>false</ShowOnlyRuleProperties>


### PR DESCRIPTION
⏩ add YASN_NAME props to override default exe name
⏩ fix ending quote position after (and not before) YASN_NAME

> I've checked and tested around with space in PATH and or NAME to have a working configuration in every case with this patch

`YASM_PATH` & `YASM_NAME` can be set via `ENV` var **WITHOUT** surrounding quote
```batch
set YASM_PATH=C:\te st
set YASM_NAME=ya sm.exe
```
or via `MSBuild` param **WITH** surrounding quote
```batch
MSBuild.exe %PATH_SRC%\%1\%VCDIR%\%MPIRDIR%\dll_mpir_%MPIR_NAME:-=_%\dll_mpir_%MPIR_NAME:-=_%.vcxproj %MSBUILD_OPTS% ^
/p:Configuration=%OUTDIR_CONF% ^
/p:Platform=%archmsbuild% ^
/p:YASM_PATH="C:\te st" ^
/p:YASM_NAME="ya sm.exe"
```
both rightly produce a working cmd line `"C:\te st\ya sm.exe" -Xvc -f x64 -g cv8 -i "..\..\..\mpn\x86_64w\\" -d "DLL" -o "x64\Release\mpn\add_err1_n.obj" -rnasm -pnasm   ..\..\..\mpn\x86_64w\skylake\avx\add_err1_n.asm`
