### PR TITLE
fix yasm error `could not open file`

### DIFF
--- a/msvc/_msvc_project.py
+++ b/msvc/_msvc_project.py
@@ -147,7 +147,8 @@ def linker_options(outf):
 def vcx_pre_build(name, plat, vs_info, outf):
 
   f1 = r'''    <PreBuildEvent>
-      <Command>cd ..\..\
+      <Command>mkdir "$(TargetPath)\..\mpn"
+cd ..\..\
 prebuild {0:s} {1:s} {2:s}
       </Command>
     </PreBuildEvent>


### PR DESCRIPTION
add `mkdir "$(TargetPath)\..\mpn"` in PreBuildEvent to avoid `yasm: could not open file `x64\Release\mpn\add_err1_n.obj'`